### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tarunmudgal8/e8bcbadb-aee5-4c61-bf07-b36e9ff9827b/e4bc0eba-3bd4-432f-ab58-d95f7b9a7a2e/_apis/work/boardbadge/9db1ca8e-02c2-41f6-ab9b-7cb2672cfc7e)](https://dev.azure.com/tarunmudgal8/e8bcbadb-aee5-4c61-bf07-b36e9ff9827b/_boards/board/t/e4bc0eba-3bd4-432f-ab58-d95f7b9a7a2e/Microsoft.RequirementCategory)
 ![SS2](https://user-images.githubusercontent.com/55023031/150823137-d14acff8-7bef-45ff-b648-624c9008175c.png)
 ![SS3](https://user-images.githubusercontent.com/55023031/150823187-b8e04e6c-8177-4b66-8e09-297452d7cf08.png)
 ![SS4](https://user-images.githubusercontent.com/55023031/150823218-03c2c498-7456-4b27-bacd-158e72b4f626.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tarunmudgal8/e8bcbadb-aee5-4c61-bf07-b36e9ff9827b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.